### PR TITLE
refactor: Remove manual trigger from ping workflow

### DIFF
--- a/.github/workflows/ping.yml
+++ b/.github/workflows/ping.yml
@@ -3,7 +3,6 @@ name: Ping Render Backend
 on:
   schedule:
     - cron: '*/14 * * * *'
-  workflow_dispatch: {}
 
 jobs:
   ping-service:


### PR DESCRIPTION
This reverts the addition of the `workflow_dispatch` trigger from the ping workflow, as per your request. The scheduled trigger is confirmed to be working as intended.